### PR TITLE
Add robust validation and error handling for journal entries

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -11,21 +11,28 @@ def add_journal_entry():
     """
     Adds a new journal entry.
 
-    The request body should be a JSON object with an 'entry' key.
-    Example: {'entry': 'This is a journal entry.'}
+    The request body should be a JSON object with a 'message' key.
+    Example: {'message': 'This is a journal entry.'}
 
     Returns:
         A JSON response with a success message and a 201 status code,
         or an error message and a 400 status code if the request is invalid.
+        Returns a 500 status code if an unexpected error occurs.
     """
-    data = request.get_json()
-    if not data or 'entry' not in data:
-        return jsonify({'error': 'Invalid request body'}), 400
+    try:
+        data = request.get_json(silent=True)
+        if not data or 'message' not in data:
+            return jsonify({'error': "'message' field is required"}), 400
+        message = data['message']
+        if not isinstance(message, str):
+            return jsonify({'error': "'message' must be a string"}), 400
 
-    entry = data['entry']
-    journal_entries.append(entry)
-    # In a real application, you would perform AI analysis on the entry here
-    return jsonify({'message': 'Journal entry added successfully'}), 201
+        journal_entries.append(message)
+        # In a real application, you would perform AI analysis on the entry here
+        return jsonify({'message': 'Journal entry added successfully'}), 201
+    except Exception:
+        app.logger.exception('Unhandled exception in add_journal_entry')
+        return jsonify({'error': 'Internal server error'}), 500
 
 @app.route('/journal', methods=['GET'])
 def get_journal_entries():
@@ -35,7 +42,11 @@ def get_journal_entries():
     Returns:
         A JSON response with a list of all journal entries.
     """
-    return jsonify({'entries': journal_entries})
+    try:
+        return jsonify({'entries': journal_entries})
+    except Exception:
+        app.logger.exception('Unhandled exception in get_journal_entries')
+        return jsonify({'error': 'Internal server error'}), 500
 
 if __name__ == '__main__':
     port = int(os.environ.get('PORT', 5000))

--- a/test_backend.py
+++ b/test_backend.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest import mock
 import json
 from backend import app
 
@@ -10,13 +11,47 @@ class BackendTestCase(unittest.TestCase):
 
     def test_add_journal_entry(self):
         # Test adding a new journal entry
-        payload = {'entry': 'This is a test journal entry.'}
+        payload = {'message': 'This is a test journal entry.'}
         response = self.app.post('/journal',
                                  data=json.dumps(payload),
                                  content_type='application/json')
         self.assertEqual(response.status_code, 201)
         data = json.loads(response.data)
         self.assertEqual(data['message'], 'Journal entry added successfully')
+
+    def test_add_journal_entry_missing_message(self):
+        # Missing 'message' field should return 400
+        payload = {}
+        response = self.app.post('/journal',
+                                 data=json.dumps(payload),
+                                 content_type='application/json')
+        self.assertEqual(response.status_code, 400)
+        data = json.loads(response.data)
+        self.assertIn('message', data['error'])
+
+    def test_add_journal_entry_invalid_type(self):
+        # Non-string 'message' should return 400
+        payload = {'message': 123}
+        response = self.app.post('/journal',
+                                 data=json.dumps(payload),
+                                 content_type='application/json')
+        self.assertEqual(response.status_code, 400)
+        data = json.loads(response.data)
+        self.assertIn('must be a string', data['error'])
+
+    def test_add_journal_entry_internal_error(self):
+        # Simulate internal server error
+        payload = {'message': 'test'}
+        class FailingList(list):
+            def append(self, *args, **kwargs):
+                raise Exception('DB failure')
+        with mock.patch('backend.journal_entries', new=FailingList()):
+            response = self.app.post('/journal',
+                                     data=json.dumps(payload),
+                                     content_type='application/json')
+        self.assertEqual(response.status_code, 500)
+        data = json.loads(response.data)
+        self.assertIn('Internal server error', data['error'])
 
     def test_get_journal_entries(self):
         # Test retrieving all journal entries


### PR DESCRIPTION
## Summary
- validate POST /journal payload for required `message` field and type
- wrap journal routes in try/except to log and return 500 on unexpected errors
- extend tests for missing field, bad type, and simulated internal errors

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a942148c048327a19e59a208149385