### PR TITLE
Ensure journal tests reset state and verify retrieval

### DIFF
--- a/test_backend.py
+++ b/test_backend.py
@@ -1,12 +1,13 @@
 import unittest
 import json
-from backend import app
+from backend import app, journal_entries
 
 class BackendTestCase(unittest.TestCase):
 
     def setUp(self):
         self.app = app.test_client()
         self.app.testing = True
+        journal_entries.clear()
 
     def test_add_journal_entry(self):
         # Test adding a new journal entry
@@ -20,10 +21,15 @@ class BackendTestCase(unittest.TestCase):
 
     def test_get_journal_entries(self):
         # Test retrieving all journal entries
+        payload = {'entry': 'Retrieval test entry'}
+        self.app.post('/journal',
+                      data=json.dumps(payload),
+                      content_type='application/json')
         response = self.app.get('/journal')
         self.assertEqual(response.status_code, 200)
         data = json.loads(response.data)
         self.assertIn('entries', data)
+        self.assertIn(payload['entry'], data['entries'])
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- Clear in-memory journal entries before each backend test
- Seed journal retrieval tests with a known entry and verify it's returned

## Testing
- `python -m unittest`

------
https://chatgpt.com/codex/tasks/task_e_68a93c0222ec83278890c644da0d1810