### PR TITLE
Add auth context and error handling

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,9 +1,13 @@
-import React, { useState, useCallback, useEffect } from 'react';
+import React, { useState, useCallback, useEffect, useContext } from 'react';
 import { GiftedChat } from 'react-native-gifted-chat';
-import { SafeAreaView, StyleSheet } from 'react-native';
+import { SafeAreaView, StyleSheet, Text, Alert } from 'react-native';
+import { AuthProvider, AuthContext } from './AuthContext';
+import ErrorBoundary from './ErrorBoundary';
 
-const App = () => {
+const Chat = () => {
   const [messages, setMessages] = useState([]);
+  const [error, setError] = useState(null);
+  const { user } = useContext(AuthContext);
 
   useEffect(() => {
     setMessages([
@@ -19,44 +23,61 @@ const App = () => {
     ]);
   }, []);
 
-  const onSend = useCallback((messages = []) => {
+  const handleSend = useCallback(async (messages = []) => {
     setMessages(previousMessages =>
       GiftedChat.append(previousMessages, messages),
     );
 
     const message = messages[0];
-    fetch('http://127.0.0.1:5000/journal', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({ entry: message.text }),
-    })
-      .then(response => response.json())
-      .then(data => {
-        console.log('Success:', data);
-      })
-      .catch(error => {
-        console.error('Error:', error);
+    try {
+      const response = await fetch('http://127.0.0.1:5000/journal', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ entry: message.text }),
       });
+      if (!response.ok) {
+        throw new Error('Network response was not ok');
+      }
+      const data = await response.json();
+      console.log('Success:', data);
+      setError(null);
+    } catch (err) {
+      console.error('Error:', err);
+      setError('Unable to send message. Please try again later.');
+      Alert.alert('Error', 'Unable to send message. Please try again later.');
+    }
   }, []);
 
   return (
     <SafeAreaView style={styles.container}>
+      {error && <Text style={styles.errorText}>{error}</Text>}
       <GiftedChat
         messages={messages}
-        onSend={messages => onSend(messages)}
-        user={{
-          _id: 1,
-        }}
+        onSend={handleSend}
+        user={user}
       />
     </SafeAreaView>
   );
 };
 
+const App = () => (
+  <AuthProvider>
+    <ErrorBoundary>
+      <Chat />
+    </ErrorBoundary>
+  </AuthProvider>
+);
+
 const styles = StyleSheet.create({
   container: {
     flex: 1,
+  },
+  errorText: {
+    color: 'red',
+    textAlign: 'center',
+    margin: 10,
   },
 });
 

--- a/AuthContext.js
+++ b/AuthContext.js
@@ -1,0 +1,16 @@
+import React, { createContext, useState } from 'react';
+
+export const AuthContext = createContext();
+
+export const AuthProvider = ({ children }) => {
+  const [user, setUser] = useState({ _id: 1, name: 'User' });
+
+  const login = userData => setUser(userData);
+  const logout = () => setUser(null);
+
+  return (
+    <AuthContext.Provider value={{ user, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};

--- a/ErrorBoundary.js
+++ b/ErrorBoundary.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(error) {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error, info) {
+    console.error('ErrorBoundary caught an error', error, info);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <View style={styles.container}>
+          <Text style={styles.text}>Something went wrong.</Text>
+        </View>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  text: {
+    fontSize: 18,
+  },
+});
+
+export default ErrorBoundary;


### PR DESCRIPTION
## Summary
- add AuthContext for user state management
- wrap chat UI in ErrorBoundary to show fallback on render failures
- improve message send API calls with try/catch and user-friendly alerts

## Testing
- `npm test` *(fails: No tests found)*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa65ca95e08327b5d181ea445ab395