### PR TITLE
Handle invalid journal entries gracefully

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -8,21 +8,24 @@ journal_entries = []
 
 @app.route('/journal', methods=['POST'])
 def add_journal_entry():
-    """
-    Adds a new journal entry.
+    """Adds a new journal entry.
 
-    The request body should be a JSON object with an 'entry' key.
-    Example: {'entry': 'This is a journal entry.'}
+    The request body should be a JSON object with an ``entry`` key whose value
+    is a non-empty string. Invalid JSON or requests missing this key will
+    result in a ``400`` error response.
 
     Returns:
-        A JSON response with a success message and a 201 status code,
-        or an error message and a 400 status code if the request is invalid.
+        A JSON response with a success message and a 201 status code, or an
+        error message and a 400 status code if the request is invalid.
     """
-    data = request.get_json()
-    if not data or 'entry' not in data:
+    data = request.get_json(silent=True)
+    if not isinstance(data, dict) or 'entry' not in data:
         return jsonify({'error': 'Invalid request body'}), 400
 
     entry = data['entry']
+    if not isinstance(entry, str) or not entry.strip():
+        return jsonify({'error': 'Invalid entry'}), 400
+
     journal_entries.append(entry)
     # In a real application, you would perform AI analysis on the entry here
     return jsonify({'message': 'Journal entry added successfully'}), 201

--- a/test_backend.py
+++ b/test_backend.py
@@ -1,12 +1,13 @@
 import unittest
 import json
-from backend import app
+from backend import app, journal_entries
 
 class BackendTestCase(unittest.TestCase):
 
     def setUp(self):
         self.app = app.test_client()
         self.app.testing = True
+        journal_entries.clear()
 
     def test_add_journal_entry(self):
         # Test adding a new journal entry
@@ -17,6 +18,35 @@ class BackendTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 201)
         data = json.loads(response.data)
         self.assertEqual(data['message'], 'Journal entry added successfully')
+
+    def test_add_journal_entry_invalid_json(self):
+        # Sending invalid JSON should return 400
+        response = self.app.post('/journal', data='{invalid', content_type='application/json')
+        self.assertEqual(response.status_code, 400)
+
+    def test_add_journal_entry_missing_entry(self):
+        # Missing 'entry' key should return 400
+        payload = {}
+        response = self.app.post('/journal',
+                                 data=json.dumps(payload),
+                                 content_type='application/json')
+        self.assertEqual(response.status_code, 400)
+
+    def test_add_journal_entry_non_string_entry(self):
+        # Non-string 'entry' should return 400
+        payload = {'entry': 123}
+        response = self.app.post('/journal',
+                                 data=json.dumps(payload),
+                                 content_type='application/json')
+        self.assertEqual(response.status_code, 400)
+
+    def test_add_journal_entry_empty_entry(self):
+        # Empty string 'entry' should return 400
+        payload = {'entry': ''}
+        response = self.app.post('/journal',
+                                 data=json.dumps(payload),
+                                 content_type='application/json')
+        self.assertEqual(response.status_code, 400)
 
     def test_get_journal_entries(self):
         # Test retrieving all journal entries


### PR DESCRIPTION
## Summary
- Improve `/journal` POST endpoint to safely parse JSON and validate entry text.
- Reject requests missing an `entry` field or providing non-string/empty values.
- Extend unit tests to cover invalid JSON and invalid entry scenarios.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a939d5073c8327938996d14b9a2472